### PR TITLE
Improve appointment booking logic to prevent double booking

### DIFF
--- a/lib/screens/appointment_detail_screen.dart
+++ b/lib/screens/appointment_detail_screen.dart
@@ -54,6 +54,21 @@ class _AppointmentDetailScreenState extends State<AppointmentDetailScreen> {
           }
 
           final appointment = snapshot.data!.data() as Map<String, dynamic>;
+
+          // Check if the selected time slot is already booked
+          if (appointment['estado'] == 'conflict') {
+            return Center(
+              child: Text(
+                'El horario seleccionado ya está reservado. Por favor, elija otro horario.',
+                style: TextStyle(
+                  fontSize: 18,
+                  color: Colors.red,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            );
+          }
+
           return SingleChildScrollView(
             padding: const EdgeInsets.all(16),
             child: Column(


### PR DESCRIPTION
Add conflict check for appointment booking in `appointment_detail_screen.dart`.

* Check if the selected time slot is already booked and display a message if it is.
* Display a message in red color if the selected time slot is already reserved.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/drackumdr/citasv2/pull/2?shareId=b5877d03-f654-477e-8a65-b1f5f0316efb).